### PR TITLE
Add missing effects

### DIFF
--- a/model/item/kind_medical.go
+++ b/model/item/kind_medical.go
@@ -11,7 +11,7 @@ type Medical struct {
 
 	Type         string  `json:"type" bson:"type"`
 	Resources    int64   `json:"resources" bson:"resources"`
-	ResourceRate int64   `json:"resourceRate" bson:"resourceRate"`
+	ResourceRate int64   `json:"resourceRate" bson:"resourceRate"` // deprecated
 	UseTime      float64 `json:"useTime" bson:"useTime"`
 	Effects      Effects `json:"effects" bson:"effects"`
 }

--- a/model/item/prop_effects.go
+++ b/model/item/prop_effects.go
@@ -2,27 +2,39 @@ package item
 
 // Effects holds all effect types
 type Effects struct {
-	Energy            *Effect `json:"energy,omitempty" bson:"energy,omitempty"`
-	Hydration         *Effect `json:"hydration,omitempty" bson:"hydration,omitempty"`
-	Bloodloss         *Effect `json:"bloodloss,omitempty" bson:"bloodloss,omitempty"`
-	Fracture          *Effect `json:"fracture,omitempty" bson:"fracture,omitempty"`
-	Contusion         *Effect `json:"contusion,omitempty" bson:"contusion,omitempty"`
-	Pain              *Effect `json:"pain,omitempty" bson:"pain,omitempty"`
-	Toxication        *Effect `json:"toxication,omitempty" bson:"toxication,omitempty"`
-	RadiationExposure *Effect `json:"radExposure,omitempty" bson:"radExposure,omitempty"`
-	Mobility          *Effect `json:"mobility,omitempty" bson:"mobility,omitempty"`
-	Recoil            *Effect `json:"recoil,omitempty" bson:"recoil,omitempty"`
-	ReloadSpeed       *Effect `json:"reloadSpeed,omitempty" bson:"reloadSpeed,omitempty"`
-	LootSpeed         *Effect `json:"lootSpeed,omitempty" bson:"lootSpeed,omitempty"`
-	UnlockSpeed       *Effect `json:"unlockSpeed,omitempty" bson:"unlockSpeed,omitempty"`
-	DestroyedPart     *Effect `json:"destroyedPart,omitempty" bson:"destroyedPart,omitempty"`
+	Energy            *Effect  `json:"energy,omitempty" bson:"energy,omitempty"`
+	EnergyRate        *Effect  `json:"energyRate,omitempty" bson:"energyRate,omitempty"`
+	Hydration         *Effect  `json:"hydration,omitempty" bson:"hydration,omitempty"`
+	HydrationRate     *Effect  `json:"hydrationRate,omitempty" bson:"hydrationRate,omitempty"`
+	Stamina           *Effect  `json:"stamina,omitempty" bson:"stamina,omitempty"`
+	StaminaRate       *Effect  `json:"staminaRate,omitempty" bson:"staminaRate,omitempty"`
+	Health            *Effect  `json:"health,omitempty" bson:"health,omitempty"`
+	HealthRate        *Effect  `json:"healthRate,omitempty" bson:"healthRate,omitempty"`
+	Bloodloss         *Effect  `json:"bloodloss,omitempty" bson:"bloodloss,omitempty"`
+	Fracture          *Effect  `json:"fracture,omitempty" bson:"fracture,omitempty"`
+	Contusion         *Effect  `json:"contusion,omitempty" bson:"contusion,omitempty"`
+	Pain              *Effect  `json:"pain,omitempty" bson:"pain,omitempty"`
+	TunnelVision      *Effect  `json:"tunnelVision,omitempty" bson:"tunnelVision,omitempty"`
+	Tremor            *Effect  `json:"tremor,omitempty" bson:"tremor,omitempty"`
+	Toxication        *Effect  `json:"toxication,omitempty" bson:"toxication,omitempty"`
+	RadiationExposure *Effect  `json:"radExposure,omitempty" bson:"radExposure,omitempty"`
+	Mobility          *Effect  `json:"mobility,omitempty" bson:"mobility,omitempty"`
+	Recoil            *Effect  `json:"recoil,omitempty" bson:"recoil,omitempty"`
+	ReloadSpeed       *Effect  `json:"reloadSpeed,omitempty" bson:"reloadSpeed,omitempty"`
+	LootSpeed         *Effect  `json:"lootSpeed,omitempty" bson:"lootSpeed,omitempty"`
+	UnlockSpeed       *Effect  `json:"unlockSpeed,omitempty" bson:"unlockSpeed,omitempty"`
+	DestroyedPart     *Effect  `json:"destroyedPart,omitempty" bson:"destroyedPart,omitempty"`
+	Skill             []Effect `json:"skill,omitempty" bson:"skill,omitempty"`
 }
 
 // Effect represents the properties of an effect
 type Effect struct {
+	Name          string          `json:"name,omitempty" bson:"name,omitempty"`
 	ResourceCosts int64           `json:"resourceCosts" bson:"resourceCosts"`
 	FadeIn        float64         `json:"fadeIn" bson:"fadeIn"`
 	FadeOut       float64         `json:"fadeOut" bson:"fadeOut"`
+	Chance        float64         `json:"chance" bson:"chance"`
+	Delay         float64         `json:"delay" bson:"delay"`
 	Duration      float64         `json:"duration" bson:"duration"`
 	Value         float64         `json:"value" bson:"value"`
 	IsPercent     bool            `json:"isPercent" bson:"isPercent"`


### PR DESCRIPTION
This PR adds all missing effects, mainly those of the stimulators.
It includes effects like tremor, tunnel vision or the regeneration rate of stamina (list below). The property `skill` holds all skills that are influenced and the respective impact on them.

The new property `health` indicates how many health points are restored and will replace `ResourceRate` from Medkits in the future.

## New effects
| Name  | Type   
| ----- | ------ |
| `energyRate` | object |
| `health` | object |
| `healthRate` | object |
| `hydrationRate` | object |
| `tunnelVision` | object |
| `stamina` | object |
| `staminaRate` | object |
| `tremor` | object |
| `skill` | array |

## New effect properties
| Name  | Type   | Description          |
| ----- | ------ | -------------------- |
| `name` | string | Name of the skill, if it affects one (optional)  |
| `chance` | float | The chance of occurrence (decimal) |
| `delay` | float | Delay in seconds |